### PR TITLE
feat: Add additional localization for the About section

### DIFF
--- a/components/AboutSection.vue
+++ b/components/AboutSection.vue
@@ -15,6 +15,10 @@ const { t } = useI18n()
     <p>
       {{ t("about_text_3") }}
     </p>
+
+    <p>
+      {{ t("about_text_4") }}
+    </p>
   </SectionApp>
 </template>
 

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -9,6 +9,7 @@
   "about_text_1": "Sóc un Desenvolupador Fullstack Senior especialitzat en Vue.js i Nuxt.js, lliurant codi d'alta qualitat, performant i exhaustivament provat per clients de tot el món. La meva experiència en frameworks JavaScript moderns garanteix aplicacions web escalables i mantenibles.",
   "about_text_2": "Em concentro en resoldre problemes complexos, no només reptes tècnics sinó també crear experiències d'usuari excepcionals que són visualment impressionants i totalment accessibles. En combinar eines poderoses amb un profund coneixement dels usuaris, dono vida a interfícies que no només són belles sinó també inclusives i funcionals.",
   "about_text_3": "Sóc un jugador d'equip col·laboratiu que prospera en entorns on podem aprendre els uns dels altres i créixer junts. Com a aprenent ràpid amb mentalitat de creixement, busco constantment nous reptes i oportunitats per expandir les meves habilitats com a desenvolupador fullstack, mantenint-me actualitzat amb tecnologies emergents i millors pràctiques.",
+  "about_text_4": "Actualment disponible per a projectes remots internacionals en tecnologies frontend i fullstack.",
   "about_download_cv": "Descarregar CV",
   "contact_title": "Pots torbar-me a 👇",
   "contact_back": "Tornar a l'inici",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -9,6 +9,7 @@
   "about_text_1": "I am an experienced Senior Fullstack Developer specializing in Vue.js and Nuxt.js, delivering high-quality, performant, and thoroughly tested code for clients worldwide. My expertise in modern JavaScript frameworks ensures scalable and maintainable web applications.",
   "about_text_2": "I focus on solving complex problems, not just technical challenges but creating exceptional user experiences that are both visually stunning and fully accessible. By combining powerful tools with deep user understanding, I bring interfaces to life that are not only beautiful but also inclusive and functional.",
   "about_text_3": "I am a collaborative team player who thrives in environments where we can learn from each other and grow together. As a fast learner with a growth mindset, I constantly seek new challenges and opportunities to expand my skills as a fullstack developer, staying current with emerging technologies and best practices.",
+  "about_text_4": "Currently available for remote international projects in frontend and fullstack technologies.",
   "about_download_cv": "Download CV",
   "contact_title": "You can reach me 👇",
   "contact_back": "Back to the top",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -9,6 +9,7 @@
   "about_text_1": "Soy un Desarrollador Fullstack Senior especializado en Vue.js y Nuxt.js, entregando código de alta calidad, performante y exhaustivamente probado para clientes de todo el mundo. Mi experiencia en frameworks JavaScript modernos garantiza aplicaciones web escalables y mantenibles.",
   "about_text_2": "Me concentro en resolver problemas complejos, no solo desafíos técnicos sino también crear experiencias de usuario excepcionales que son visualmente impresionantes y totalmente accesibles. Al combinar herramientas poderosas con un profundo conocimiento de los usuarios, doy vida a interfaces que no solo son hermosas sino también inclusivas y funcionales.",
   "about_text_3": "Soy un jugador de equipo colaborativo que prospera en entornos donde podemos aprender unos de otros y crecer juntos. Como aprendiz rápido con mentalidad de crecimiento, busco constantemente nuevos desafíos y oportunidades para expandir mis habilidades como desarrollador fullstack, manteniéndome actualizado con tecnologías emergentes y mejores prácticas.",
+  "about_text_4": "Actualmente disponible para proyectos remotos internacionales en tecnologías frontend y fullstack.",
   "about_download_cv": "Descargar CV",
   "contact_title": "Puedes encontrarme en 👇",
   "contact_back": "Volver al inicio",


### PR DESCRIPTION
Add additional localization for the About section, including a new availability message in English, Catalan, and Spanish.